### PR TITLE
Fix issue with generated pdftk.sh file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ echo "-----> heroku-pdftk-buildpack: Installed to app/bin. ${show_version}"
 # Setting environment variables in .profile.d script (sourced at dyno startup)
 mkdir -p "$1/.profile.d/"
 cat <<EOF >"$1"/.profile.d/pdftk.sh
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/bin
+export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$HOME/bin"
 EOF
 
 exit 0


### PR DESCRIPTION
When `~/.profile.d/pdftk.sh` is generated it is creating the file with
the _expanded value_ of $LD_LIBRARY_PATH, instead of the string
"$LD_LIBRARY_PATH". This presents a problem because it can (and does)
clobber the LD_LIBRARY_PATH set by other scripts.

For example, if this script gets called after other buildpacks are run,
it will set the LD_LIBRARY_PATH to ":app/bin". This causes an issue with
other binaries from other buildpacks trying to run with shared objects
that live in the LD_LIBRARY_PATH's that are set previously.

This commit fixes the problem by escaping the `$` and writing the ENV to
the shell script instead of the values in LD_LIBRARY_PATH and HOME.